### PR TITLE
Remove regex replaces.

### DIFF
--- a/html2text.go
+++ b/html2text.go
@@ -3,17 +3,11 @@ package html2text
 import (
 	"bytes"
 	"io"
-	"regexp"
 	"strings"
 	"unicode"
 
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
-)
-
-var (
-	spacingRe = regexp.MustCompile(`[ \r\n\t]+`)
-	newlineRe = regexp.MustCompile(`\n\n+`)
 )
 
 type textifyTraverseCtx struct {
@@ -27,6 +21,48 @@ type textifyTraverseCtx struct {
 	justClosedDiv   bool
 }
 
+func trimSpace(in string) string {
+	res := []string{}
+	current := []byte{}
+	for _, v := range []byte(in) {
+		switch v {
+		case ' ', '\t', '\n', '\r':
+			if len(current) > 0 {
+				res = append(res, string(current))
+				current = []byte{}
+			}
+		default:
+			current = append(current, v)
+		}
+	}
+	if len(current) > 0 {
+		// last word
+		res = append(res, string(current))
+	}
+	return strings.Join(res, " ")
+}
+
+func trimMultilines(in string) string {
+	res := []byte{}
+	count := 0
+	for _, v := range []byte(in) {
+		if v == '\n' {
+			switch count {
+			case 0, 1:
+				count++
+				res = append(res, v)
+			default:
+				count++
+			}
+		} else {
+			count = 0
+			res = append(res, v)
+		}
+	}
+
+	return string(res)
+}
+
 func (ctx *textifyTraverseCtx) traverse(node *html.Node) error {
 	switch node.Type {
 
@@ -34,7 +70,7 @@ func (ctx *textifyTraverseCtx) traverse(node *html.Node) error {
 		return ctx.traverseChildren(node)
 
 	case html.TextNode:
-		data := strings.Trim(spacingRe.ReplaceAllString(node.Data, " "), " ")
+		data := trimSpace(node.Data)
 		return ctx.emit(data)
 
 	case html.ElementNode:
@@ -281,8 +317,9 @@ func FromHtmlNode(doc *html.Node) (string, error) {
 		return "", err
 	}
 
-	text := strings.TrimSpace(newlineRe.ReplaceAllString(
-		strings.Replace(ctx.Buf.String(), "\n ", "\n", -1), "\n\n"))
+	text := strings.TrimSpace(
+		trimMultilines(strings.Replace(ctx.Buf.String(), "\n ", "\n", -1)),
+	)
 	return text, nil
 
 }


### PR DESCRIPTION
Problem: the library spends too much time locking regexes, according
to the discussion[1]

"If the lock there is dominating performance, then it means the regexp
is super trivial.  In that case you will get an even bigger speedup by
just writing some code instead of doing a regexp match."

So, this commit replaces them with traversing the string by each byte
O(n) and replacing them.

[1] https://github.com/golang/go/issues/8232